### PR TITLE
update node color

### DIFF
--- a/rate.html
+++ b/rate.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('rate',{
         category: 'function',
-        color: '#167bcf',
+        color: '#3ca3fa',
         defaults: {
             name: {value:""},
 	    inputField: {value: "payload"},


### PR DESCRIPTION
A node's colour is too dark to fit in the standard Nodered palette and makes it difficult to read the default dark-fonted name of the node. I have chosen a slightly lighter colour. 